### PR TITLE
Eleven: Fix crash in LetterTileDrawable

### DIFF
--- a/src/com/cyanogenmod/eleven/widgets/LetterTileDrawable.java
+++ b/src/com/cyanogenmod/eleven/widgets/LetterTileDrawable.java
@@ -135,7 +135,7 @@ public class LetterTileDrawable extends Drawable {
         }
 
         // Draw letter/digit only if the first character is an english letter
-        if (mDisplayName != null
+        if (mDisplayName != null && !mDisplayName.isEmpty()
                 && isEnglishLetter(mDisplayName.charAt(0))) {
             int numChars = 1;
 


### PR DESCRIPTION
- Make sure that the title string is not empty.

Change-Id: Ifa4b4f916f476519ecef19629e5b9d33ac0642e1
Signed-off-by: morckx <morckx@gmail.com>